### PR TITLE
Fix user email include statement

### DIFF
--- a/src/helpers/userHelpers.ts
+++ b/src/helpers/userHelpers.ts
@@ -13,11 +13,6 @@ export const findUserById = async (id: string) => {
 export const findUserByEmail = async (email: string) => {
   const user = await prisma.user.findUnique({
     where: { email },
-    include: {
-      superAdmin: { select: { id: true } },
-      admin: { select: { id: true } },
-      careManager: { select: { id: true } },
-    },
   });
 
   if (!user) throw new ApiError(404, "User Not Found");


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove invalid `include` statement from `findUserByEmail` as the relations are not defined in the Prisma schema.

---
<a href="https://cursor.com/background-agent?bcId=bc-61aa7653-9c78-4405-8697-6413e3cb151a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61aa7653-9c78-4405-8697-6413e3cb151a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>