### PR TITLE
Fix jwt overload problem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@prisma/client": "^6.2.1",
         "@types/bcrypt": "^5.0.2",
-        "@types/jsonwebtoken": "^9.0.9",
+        "@types/jsonwebtoken": "^9.0.10",
         "bcrypt": "^5.1.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
@@ -698,9 +698,9 @@
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.9.tgz",
-      "integrity": "sha512-uoe+GxEuHbvy12OUQct2X9JenKM3qAscquYymuQN4fMWG9DBQtykrQEFcAbVACF7qaLw9BePSodUL0kquqBJpQ==",
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@prisma/client": "^6.2.1",
     "@types/bcrypt": "^5.0.2",
-    "@types/jsonwebtoken": "^9.0.9",
+    "@types/jsonwebtoken": "^9.0.10",
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/src/app/middleware/auth.ts
+++ b/src/app/middleware/auth.ts
@@ -2,7 +2,6 @@ import { NextFunction, Request, Response } from "express";
 import ApiError from "../errors/ApiError";
 import { jwtHelpers } from "../../helpers/jwtHelpers";
 import config from "../../config";
-import { Secret } from "jsonwebtoken";
 
 const auth = (...roles: string[]) => {
   return async (
@@ -24,7 +23,7 @@ const auth = (...roles: string[]) => {
 
       const verifiedUser = jwtHelpers.verifyToken(
         tokenWithoutBearer,
-        config.jwt.jwt_secret as Secret
+        config.jwt.jwt_secret as string
       );
 
       req.user = verifiedUser;

--- a/src/app/modules/Auth/auth.services.ts
+++ b/src/app/modules/Auth/auth.services.ts
@@ -1,10 +1,11 @@
-import { Secret } from "jsonwebtoken";
-import config from "../../../config";
-import { jwtHelpers } from "../../../helpers/jwtHelpers";
-import { findUserByEmail } from "../../../helpers/userHelpers";
-import ApiError from "../../errors/ApiError";
-import prisma from "../../shared/prisma";
 import bcrypt from "bcrypt";
+import ApiError from "../../errors/ApiError";
+import { User } from "@prisma/client";
+import { jwtHelpers } from "../../../helpers/jwtHelpers";
+import config from "../../../config";
+import { findUserByEmail } from "../../../helpers/userHelpers";
+import prisma from "../../shared/prisma";
+import type { StringValue } from "ms";
 
 type TLogin = {
   email: string;
@@ -28,14 +29,14 @@ const login = async (payload: TLogin) => {
 
   const accessToken = jwtHelpers.generateToken(
     userWithoutPassword,
-    config.jwt.jwt_secret as Secret,
-    config.jwt.expires_in as string
+    config.jwt.jwt_secret as string,
+    config.jwt.expires_in as StringValue
   );
 
   const refreshToken = jwtHelpers.generateToken(
     userWithoutPassword,
-    config.jwt.refresh_token_secret as Secret,
-    config.jwt.refresh_token_expires_in as string
+    config.jwt.refresh_token_secret as string,
+    config.jwt.refresh_token_expires_in as StringValue
   );
 
   return {

--- a/src/helpers/jwtHelpers.ts
+++ b/src/helpers/jwtHelpers.ts
@@ -1,15 +1,18 @@
-import jwt, { JwtPayload, Secret } from "jsonwebtoken";
+import jwt, { JwtPayload, SignOptions } from "jsonwebtoken";
+import type { StringValue } from "ms";
 
-const generateToken = (payload: any, secret: Secret, expiresIn: string) => {
-  const token = jwt.sign(payload, secret, {
+const generateToken = (payload: any, secret: string, expiresIn: StringValue | number): string => {
+  const options: SignOptions = {
     algorithm: "HS256",
     expiresIn,
-  });
+  };
+  
+  const token = jwt.sign(payload, secret, options);
 
   return token;
 };
 
-const verifyToken = (token: string, secret: Secret) => {
+const verifyToken = (token: string, secret: string): JwtPayload => {
   const tokenWithoutQuotes = token.replace(/^"|"$/g, "");
 
   const verifiedUser = jwt.verify(tokenWithoutQuotes, secret) as JwtPayload;


### PR DESCRIPTION
Fix JWT import and overload issues by using string types for secrets and `StringValue` for expiration.

The `Secret` type from `jsonwebtoken` was causing TypeScript overload errors because environment variables, which hold the JWT secrets, are strings. This PR updates the type definitions to consistently use `string` for secrets and introduces `StringValue` from the `ms` package for the `expiresIn` parameter, which better represents the accepted string formats for expiration times in `jwt.sign`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e15fbaab-d039-4702-ab3d-f7a236fa3c6b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e15fbaab-d039-4702-ab3d-f7a236fa3c6b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>